### PR TITLE
Rename output file to as-enclosure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-index.js
+as-enclosure

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "node_modules/.bin/esbuild --target=es2019 ./src/index.tsx --bundle --platform=node --outfile=index.js"
+    "build": "node_modules/.bin/esbuild --target=es2019 ./src/index.tsx --bundle --platform=node --outfile=as-enclosure --banner:js='#!/usr/bin/env node'"
   },
   "dependencies": {
     "d3": "^7.0.1",


### PR DESCRIPTION
from `index.js`. The file is now also specifies a shebang so that it can
be run directly.