### PR TITLE
Minify output bundle

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "node_modules/.bin/esbuild --target=es2019 ./src/index.tsx --bundle --platform=node --outfile=as-enclosure --banner:js='#!/usr/bin/env node'"
+    "build": "node_modules/.bin/esbuild --target=es2019 ./src/index.tsx --bundle --platform=node --minify --define:process.env.NODE_ENV='\"production\"' --outfile=as-enclosure --banner:js='#!/usr/bin/env node'"
   },
   "dependencies": {
     "d3": "^7.0.1",


### PR DESCRIPTION
This reduces the bundle size from 505 KB -> 146.4 KB.

`NODE_ENV` is set so that the development code for react-dom-server can be
optimized away.